### PR TITLE
feat: Support copying decrypted only m4b files to audiobookshelf

### DIFF
--- a/BALD.sh
+++ b/BALD.sh
@@ -455,12 +455,19 @@ function move_files() {
   annots_file="$dirnam/$title-annotations.json"
   pdf_file="$dirnam/$title.pdf"
   cover_file=$(du "$dirnam/${title}"*jpg | sort -nr | head -1 | cut -f2)
+
+  if [[ "$CONVERT_DECRYPTONLY" == "true" ]]; then
+    move_to_file="$2/$3.m4b"
+  else
+    move_to_file="$2/$3.oga"
+  fi
+
   # Move audio file
   if [[ "$DEBUG" == "true" ]]; then
-    echo "### DEBUG: Copy converted audiobook: $cover_file"
-    cp "$1" "$2/$3.oga"
+    echo "### DEBUG: Copy converted audiobook: $1 to $move_to_file"
+    cp "$1" "$move_to_file"
   else
-    mv "$1" "$2/$3.oga"
+    mv "$1" "$move_to_file"
   fi
   # Copy cover
   if [[ "$DEST_COPY_COVER" == true ]]; then
@@ -830,7 +837,12 @@ rm -f "$SCRIPT_DIR/tmp/${NOW}_statistics.txt"
 } > "$SCRIPT_DIR/tmp/${NOW}_statistics.txt"
 #########################################################################################################################
 # Converted audiobooks list
-my_ogabooks=$(find "$DOWNLOAD_DIR/$NOW" -maxdepth 1 -type f -name '*oga' | sort)
+if [[ "$CONVERT_DECRYPTONLY" == "true" ]]; then
+  my_ogabooks=$(find "$DOWNLOAD_DIR/$NOW" -maxdepth 1 -type f -name '*m4b' | sort)
+else 
+  my_ogabooks=$(find "$DOWNLOAD_DIR/$NOW" -maxdepth 1 -type f -name '*oga' | sort)
+fi
+# my_ogabooks=$(find "$DOWNLOAD_DIR/$NOW" -maxdepth 1 -type f -name '*oga' | sort)
 if [[ -n "$my_ogabooks" ]]; then
 #########################################################################################################################
 # Move converted audiobooks to final destination & delete downloaded files

--- a/BALD.sh
+++ b/BALD.sh
@@ -737,9 +737,9 @@ function convert_audio() {
   fi
   # Decrypt only OR Convert
   if [[ "$CONVERT_DECRYPTONLY" == "true" ]]; then
-    ffmpeg -y -nostdin -loglevel warning -stats "${decrypt_param[@]}" \
-          -i "$my_audiobook" -i "${my_audiobook}_metadata_new" -f ffmetadata \
-          -c copy -map 0:a -map_metadata 1 \
+    # Decrypt the audiobook and copy the stream with new metadata to a new m4b file 
+    ffmpeg -y -nostdin -loglevel warning "${decrypt_param[@]}" -i "$my_audiobook" -i "${my_audiobook}_metadata_new" \
+	  -map 0:a:0 -c copy -dn -map_metadata 1 -map_chapters 1 -movflags use_metadata_tags \
           "$my_audiobook".m4b
     if [[ "$DEBUG_METADATA" == "true" ]]; then
       echo "### DEBUG METADATA: ${my_audiobook}.m4b_metadata"

--- a/BALD.sh
+++ b/BALD.sh
@@ -844,12 +844,11 @@ rm -f "$SCRIPT_DIR/tmp/${NOW}_statistics.txt"
 #########################################################################################################################
 # Converted audiobooks list
 if [[ "$CONVERT_DECRYPTONLY" == "true" ]]; then
-  my_ogabooks=$(find "$DOWNLOAD_DIR/$NOW" -maxdepth 1 -type f -name '*m4b' | sort)
+  my_audiobooks=$(find "$DOWNLOAD_DIR/$NOW" -maxdepth 1 -type f -name '*m4b' | sort)
 else 
-  my_ogabooks=$(find "$DOWNLOAD_DIR/$NOW" -maxdepth 1 -type f -name '*oga' | sort)
+  my_audiobooks=$(find "$DOWNLOAD_DIR/$NOW" -maxdepth 1 -type f -name '*oga' | sort)
 fi
-# my_ogabooks=$(find "$DOWNLOAD_DIR/$NOW" -maxdepth 1 -type f -name '*oga' | sort)
-if [[ -n "$my_ogabooks" ]]; then
+if [[ -n "$my_audiobooks" ]]; then
 #########################################################################################################################
 # Move converted audiobooks to final destination & delete downloaded files
   if [[ "$DEBUG_SKIPMOVEBOOKS" != "true" ]]; then
@@ -931,7 +930,7 @@ if [[ -n "$my_ogabooks" ]]; then
         cd "$(dirname "$audiobook")" && rm -f "${tmp_asin}"*
         cd "$SCRIPT_DIR" || { echo "=== ERROR Cannot cd back to script directory"; exit 255; }
       fi
-    done <<< "$my_ogabooks"
+    done <<< "$my_audiobooks"
     # Update local db
     cat "$SCRIPT_DIR/tmp/${NOW}_local_db.tsv" >> "$LOCAL_DB"
   else

--- a/BALD.sh
+++ b/BALD.sh
@@ -35,6 +35,7 @@ DOWNLOAD_DIR=$SCRIPT_DIR/downloads    # AAX & AAXC Audible files will be downloa
 DEST_BASE_DIR=$SCRIPT_DIR/audiobooks  # Directory for converted files (will be created if it doesnt exist)
 DEBUG_USEAAXSAMPLE=false              # AAX sample file to be encoded instead of big Audiobook (fast convert) (false to disable)
 DEBUG_USEAAXCSAMPLE=false             # AAXC sample file (false to disable) dont forget to put 'sample.voucher' in same dir
+METADATA_TIKA=http://tikahost:9998    # Tika http url without trailing slash short timeouts (1 sec for validation, 2s for lang detection)
 
 #### Source docker_mod.sh for container execution safety
 if [[ -f "$SCRIPT_DIR"/docker_mod.sh ]]; then
@@ -62,7 +63,6 @@ DOWNLOAD_JOBS=2                       # (disabled for now) 1 less errors, 2 seem
 DOWNLOAD_RETRIES=3                    # Careful of not hammering Amazon servers by keeping this param low
 METADATA_PARALLEL=4                   # Number of parallel jobs for metadata workload >= 1 (1 to do sequential conversion)
 METADATA_SOURCE=all                   # 'aax' (source metadata from aax or aaxc) or 'all' (metadata from every possible sources)
-METADATA_TIKA=http://tikahost:9998    # Tika http url without trailing slash short timeouts (1 sec for validation, 2s for lang detection)
 METADATA_CLEAN_AUTHOR_PATTERN='*'     # Read README.md
 METADATA_SINGLENAME_AUTHORS=true      # Keep single name authors or not
 METADATA_SKIP_IFEXISTS=false          # Skip metadata processing if AAXFILE_metadata_new exists
@@ -662,7 +662,7 @@ function build_metadata() {
     if [[ "${#description}" -gt "100" ]]; then
       lang=""
       if [[ "$TIKA_METHOD" == "java" ]]; then
-        lang=$(java -jar "$SCRIPT_DIR/$METADATA_TIKA" -l - <<< "$description")
+        lang=$(java -jar "$METADATA_TIKA" -l - <<< "$description")
       elif [[ "$TIKA_METHOD" == "server" ]]; then
         lang=$(curl -s --connect-timeout 2 -T- ${METADATA_TIKA}/meta/language --header "Accept: text/plain" <<< "$description")
       fi

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,0 +1,12 @@
+services:
+  bald:
+    build: .
+    environment:
+      - TZ=Etc/UTC
+    volumes:
+      - /home/mysuser/.audible:/root/.audible
+      - /home/mysuser/AudioBookShelf/audiobooks:/audiobooks_dest
+      - /home/mysuser/BALD/downloads:/audible_dl
+      - /home/mysuser/BALD/config:/BALD/config
+      - /home/mysuser/BALD/db:/BALD/db
+      - /home/mysuser/BALD/tmp:/BALD/tmp

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,5 +1,5 @@
 services:
-  bald:
+  BALD:
     build: .
     environment:
       - TZ=Etc/UTC

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,12 +2,11 @@ services:
   BALD:
     image: quay.io/damajor/bald:latest
     environment:
-      - TZ=Europe/Rome
+      - TZ=Etc/UTC
     volumes:
       - /home/mysuser/.audible:/root/.audible
-      - /home/mysuser/Audible/lib_history:/audible_history
-      - /home/mysuser/Audible/audible_last_sync:/status_file
-      - /home/mysuser/Audible/downloads:/audible_dl
       - /home/mysuser/AudioBookShelf/audiobooks:/audiobooks_dest
-      - /home/mysuser/BALD/myconfig:/BALD/myconfig
-      - /home/mysuser/BALD/tmp:/BALD/tmp
+      - /home/mysuser/BALD/downloads:/audible_dl
+      - /home/mysuser/BALD/config:/BALD/config
+      - /home/mysuser/BALD/db:/BALD/db
+      # - /home/mysuser/BALD/tmp:/BALD/tmp # Uncomment to keep the tmp files outside the container

--- a/config/config
+++ b/config/config
@@ -1,0 +1,1 @@
+AUDIBLECLI_PROFILE=profile

--- a/docker_mod.sh
+++ b/docker_mod.sh
@@ -7,17 +7,15 @@ if [[ -n "$container" || "$INCONTAINER" == "true" ]]; then
   [[ "$DEBUG" == "true" ]] && echo "### DEBUG Container detected"
   echo ">>> Container variables auto settings"
 
-  mounts=(/audible_dl /audiobooks_dest /root/.audible)
+  mounts=(/audiobooks_dest /root/.audible)
   for dir in "${mounts[@]}"; do
     grep -q "$dir" /proc/mounts || { echo "=== ERROR: Missing '$dir'"; exit 2; }
   done
 
-  unset DOWNLOAD_DIR
   unset DEST_BASE_DIR
   unset DEBUG_USEAAXSAMPLE
   unset DEBUG_USEAAXCSAMPLE
 
-  declare -r DOWNLOAD_DIR="/audible_dl"
   declare -r DEST_BASE_DIR="/audiobooks_dest"
   declare -r DEBUG_USEAAXSAMPLE="sample.aax"
   declare -r DEBUG_USEAAXCSAMPLE="sample.aaxc"

--- a/docker_mod.sh
+++ b/docker_mod.sh
@@ -20,7 +20,7 @@ if [[ -n "$container" || "$INCONTAINER" == "true" ]]; then
   declare -r DEBUG_USEAAXSAMPLE="sample.aax"
   declare -r DEBUG_USEAAXCSAMPLE="sample.aaxc"
 
-  METADATA_TIKA=/BALD/tika-app-2.9.2.jar
+  METADATA_TIKA=/BALD/tika-app.jar
 else
   [[ "$DEBUG" == "true" ]] && echo "### DEBUG Not in container"
 fi

--- a/docker_mod.sh
+++ b/docker_mod.sh
@@ -7,28 +7,22 @@ if [[ -n "$container" || "$INCONTAINER" == "true" ]]; then
   [[ "$DEBUG" == "true" ]] && echo "### DEBUG Container detected"
   echo ">>> Container variables auto settings"
 
-  mounts=(/audible_history /status_file /audible_dl /audiobooks_dest /BALD/myconfig /BALD/tmp /BALD/personal_library.tsv /root/.audible)
+  mounts=(/audible_dl /audiobooks_dest /root/.audible)
   for dir in "${mounts[@]}"; do
     grep -q "$dir" /proc/mounts || { echo "=== ERROR: Missing '$dir'"; exit 2; }
   done
 
-  unset HIST_LIB_DIR
-  unset STATUS_FILE
   unset DOWNLOAD_DIR
   unset DEST_BASE_DIR
   unset DEBUG_USEAAXSAMPLE
   unset DEBUG_USEAAXCSAMPLE
-  unset LOCAL_DB
 
-  declare -r HIST_LIB_DIR="/audible_history"
-  declare -r STATUS_FILE="/status_file"
   declare -r DOWNLOAD_DIR="/audible_dl"
   declare -r DEST_BASE_DIR="/audiobooks_dest"
   declare -r DEBUG_USEAAXSAMPLE="sample.aax"
   declare -r DEBUG_USEAAXCSAMPLE="sample.aaxc"
-  declare -r LOCAL_DB="/BALD/personal_library.tsv"
 
-  METADATA_TIKA=tika-app-2.9.2.jar
+  METADATA_TIKA=/BALD/tika-app-2.9.2.jar
 else
   [[ "$DEBUG" == "true" ]] && echo "### DEBUG Not in container"
 fi

--- a/grab_additional_scripts.sh
+++ b/grab_additional_scripts.sh
@@ -6,14 +6,6 @@
 
 SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 
-
-if [[ ! -f "$SCRIPT_DIR"/myconfig ]]; then
-  echo ">>> Creating myconfig file with default parameters..."
-  echo "### PUT YOUR SETTING PARAMETERS HERE ###" > "$SCRIPT_DIR"/myconfig
-                                                                                                                          # TODO CHANGE NAME
-  sed -n "/#### User config/,/#### End of user config/ {/#### User config/b;/#### End of user config/b;p}" "$SCRIPT_DIR"/BALD.sh >> "$SCRIPT_DIR"/myconfig
-fi
-
 if [ ! -f "$SCRIPT_DIR/ogg-image-blobber.sh" ]; then
   echo ">>> Downloading ogg-image-blobber.sh"
   curl -o "$SCRIPT_DIR"/ogg-image-blobber.sh \
@@ -29,6 +21,6 @@ fi
 
 if [[ ! -f "$(find "$SCRIPT_DIR" -name 'tika-app-*.jar')" ]]; then
   echo ">>> Downloading Apache Tika jar"
-  curl -o "$SCRIPT_DIR"/tika-app-2.9.2.jar \
-    https://dlcdn.apache.org/tika/2.9.2/tika-app-2.9.2.jar
+  curl -o "$SCRIPT_DIR"/tika-app.jar \
+    https://dlcdn.apache.org/tika/2.9.3/tika-app-2.9.3.jar
 fi


### PR DESCRIPTION
# Overview

Various changes included to also improve overall usage

## Copy M4B to AudioBookShelf

If `CONVERT_DECRYPTONLY` is `true` then it will move the `.m4b` file to the audiobooks destination folder instead of expecting an `.oga` file.

Updated the ffmpeg command to generating the `.m4b` file to map in the metadata that is created, this will make sure it gets the same metadata that an `.oga` file would get.

## Default File location changes

This includes a refactor to how various files are stored. This is to improve working with containers as docker doesn't behave well when volume mapping a file (it created a folder if the file doesn't exist). It also reduces the number of volume mappings required by default.

* added a `config` folder with a very basic `config` file inside.
* added a `db` folder with an empty `personal_library.tsv` file
* `audible_last_sync` stored inside the `db` folder
* `lib_history` stored inside the `db` folder

You can still override all the file locations in the config file using the same names as before.

## Tika App

If using the java app `METADATA_TIKA` now expects an absolute path to the jar file.

Also updated the docker build to get 2.9.3 as 2.9.2 has been removed from the mirror

## DEST_DIR_OVERWRITE Default

The code suggests the default should be `true`, but it was set to `false`. I've updated the default value to `true`

## Updated Docker

Changes to the docker related files to work with the above changes

* Updated the `docker_mod.sh` to work with the new directory structure
* Added a `compose.dev.yml` that will build the docker file and use that.
* Updated `compose.yml` to use the new location paths defined above

